### PR TITLE
Better batch endpoint: accepts multiply texts, returns also segmented…

### DIFF
--- a/app/src/main/groovy/ua/net/nlp/api/BatchController.groovy
+++ b/app/src/main/groovy/ua/net/nlp/api/BatchController.groovy
@@ -29,8 +29,19 @@ class BatchController extends BaseController {
     @Autowired
     BatchService batchService
 
+    def validateRequest(BatchRequest request) {
+        // To Andriy. I think we should allow empty strings, but we clearly should disallow long ones.
+        // How I can assert that all the strings in the list are shorter than TEXT_LIMIT?
+        if( ! request.texts ) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Texts are empty.")
+        }
 
-    @Operation(summary = "Clean, tokenize, and lemmatize the text"
+        if( request.texts.size() > 100 ) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Too many texts.")
+        }
+    }
+
+    @Operation(summary = "Clean, tokenize, and lemmatize the texts"
     )
     @ApiResponses(value = [
             @ApiResponse(responseCode = "200", description = "OK"),
@@ -39,14 +50,21 @@ class BatchController extends BaseController {
     @PostMapping(path="/batch")
     def batch(
         @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            description='Body text; e.g<br>{"text": "Сьогодні y продажi «ХХІ століття»."}', 
+            description='Body text; e.g<br>{"texts": ["Сьогодні y продажi «ХХІ століття»."]}', 
             required = true)
         @RequestBody BatchRequest request) {
         
         validateRequest(request)
 
         try {
-            batchService.batch(request.text)
+            // To Andriy. Can I use parallel here? groovy gave me the error when compiling.
+            // Maybe it is related to the old version of it?
+            // Groovy Version: 4.0.5 JVM: 17.0.4.1 Vendor: Homebrew OS: Mac OS X
+            // It's not a mandatory option, so if it's hard to implement, I'd rather skip this one
+            // return request.texts.parallel().collect { text ->
+            return request.texts.collect { text ->
+                batchService.batch(text)
+            }
         }
         catch(Exception e) {
             e.printStackTrace()
@@ -57,13 +75,18 @@ class BatchController extends BaseController {
 
     @Schema(description="Request to clean, tokenize, and lemmatize text.")
     @CompileStatic
-    static class BatchRequest extends RequestBase {
+    static class BatchRequest {
+        @Schema(description="Texts to process.")
+        List<String> texts
     }
+
 
     @Schema(description="Response with tokenized and lemmatized text.")
     @CompileStatic
     static class BatchResponse {
+        String clean
         List<List<String>> tokenized
         List<List<String>> lemmatized
+        List<String> segmented
     }
 }

--- a/app/src/main/groovy/ua/net/nlp/api/services/BatchService.groovy
+++ b/app/src/main/groovy/ua/net/nlp/api/services/BatchService.groovy
@@ -44,7 +44,7 @@ class BatchService {
         def tagged = lemmatizeService.tagger.tagTextCore(sentences, null)
         def lemmatized = lemmatizeService.lemmatizeTokens(tagged)
         
-        return new BatchResponse(tokenized: tokenized, lemmatized: lemmatized, clean: response.text, segmented: segments)
+        return new BatchResponse(tokens: tokenized, lemmas: lemmatized, cleanText: response.text, sentences: segments)
     }
     
 }

--- a/app/src/main/groovy/ua/net/nlp/api/services/BatchService.groovy
+++ b/app/src/main/groovy/ua/net/nlp/api/services/BatchService.groovy
@@ -35,12 +35,16 @@ class BatchService {
                 at.getToken()
             }
         }
+        def segments = sentences.collect(s -> 
+            s.getText().trim()
+        )
+
         tokenizeService.trim(tokenized)
         
         def tagged = lemmatizeService.tagger.tagTextCore(sentences, null)
         def lemmatized = lemmatizeService.lemmatizeTokens(tagged)
         
-        return new BatchResponse(tokenized: tokenized, lemmatized: lemmatized)
+        return new BatchResponse(tokenized: tokenized, lemmatized: lemmatized, clean: response.text, segmented: segments)
     }
     
 }

--- a/app/src/test/groovy/nlp_uk_api/HttpRequestTest.groovy
+++ b/app/src/test/groovy/nlp_uk_api/HttpRequestTest.groovy
@@ -69,10 +69,19 @@ public class HttpRequestTest {
     public void testBatch() throws Exception {
         def url = "http://localhost:" + port + "/batch"
         // лат. літери в укр словах + кирилиця в XXI 
-        def request = new BatchRequest(text: "Сьогодні y про\u00ACдажi. Екс-«депутат» у XХІ столітті.")
-        BatchResponse resp = restTemplate.postForObject(url, request, BatchResponse.class)
-        assertEquals ([["Сьогодні", " ", "у", " ", "продажі", "."], ["Екс-«депутат»", " ", "у", " ", "XXI", " ", "столітті", "."]], resp.tokenized)
-        assertEquals ([["сьогодні", "у", "продаж"], ["екс-депутат", "у", "XXI", "століття"]], resp.lemmatized)
+        def request = new BatchRequest(texts: ["Сьогодні y про\u00ACдажi. Екс-«депутат» у XХІ столітті.", "Привіт, як справи?"])
+        List<BatchResponse> resp = restTemplate.postForObject(url, request, BatchResponse[].class)
+
+        assertEquals ("Сьогодні у продажі. Екс-«депутат» у XXI столітті.", resp[0].cleanText)
+        assertEquals (["Сьогодні у продажі.", "Екс-«депутат» у XXI столітті."], resp[0].sentences)
+        assertEquals ([["Сьогодні", " ", "у", " ", "продажі", "."], ["Екс-«депутат»", " ", "у", " ", "XXI", " ", "столітті", "."]], resp[0].tokens)
+        assertEquals ([["сьогодні", "у", "продаж"], ["екс-депутат", "у", "XXI", "століття"]], resp[0].lemmas)
+
+        assertEquals ("Привіт, як справи?", resp[1].cleanText)
+        assertEquals (["Привіт, як справи?"], resp[1].sentences)
+        assertEquals ([["Привіт", ",", " ", "як", " ", "справи", "?"]], resp[1].tokens)
+        assertEquals ([["привіт", "як", "справа"]], resp[1].lemmas)
+        assertEquals(resp.size(), 2)
     }
     
     @Test
@@ -85,18 +94,19 @@ public class HttpRequestTest {
 //        def cnt = (int)(15*1024*1024 / w.length())
 //        def text = w.repeat(cnt)
         def text = bigFile.getText('UTF-8')
-        def request = new BatchRequest(text: text)
+        def request = new BatchRequest(texts: [text])
 
         BatchResponse resp = restTemplate.postForObject(url, request, BatchResponse.class)
         
-        assertNotNull resp.tokenized
-        assertEquals 67182, resp.tokenized.size()
-        assertEquals 9, resp.tokenized[0].size()
+        assertEquals 67182, resp.sentences.size()
+        assertNotNull resp.tokens
+        assertEquals 67182, resp.tokens.size()
+        assertEquals 9, resp.tokens[0].size()
 //        assertEquals(['Машини', ' ', '-', ' ', 'не', ' ', 'розкіш', '...'. "\n"], resp.tokenized[0])
 
-        assertNotNull resp.lemmatized
-        assertEquals 67182, resp.lemmatized.size()
-        assertEquals(['машина', 'не', 'розкіш'], resp.lemmatized[0])
+        assertNotNull resp.lemmas
+        assertEquals 67182, resp.lemmas.size()
+        assertEquals(['машина', 'не', 'розкіш'], resp.lemmas[0])
     }
 
 }


### PR DESCRIPTION
… and cleansed version of the text alongside with tokenized and lemmatized

Please also take a look at the questions I left in the comments